### PR TITLE
package: esm: dependencies -> devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "esm": "^3.2.25",
     "jest": "^24.8.0"
   },
   "devDependencies": {
@@ -24,6 +23,7 @@
     "@babel/core": "^7.2.2",
     "@babel/plugin-transform-modules-commonjs": "^7.2.0",
     "@babel/preset-env": "^7.2.3",
-    "daggy": "^1.3.0"
+    "daggy": "^1.3.0",
+    "esm": "^3.2.25"
   }
 }


### PR DESCRIPTION
Looks like `esm` should be in devDependencies, it is only used in `examples`