### PR TITLE
Fix fork() usage in tutorial

### DIFF
--- a/tutorial/tutorial-part-3.md
+++ b/tutorial/tutorial-part-3.md
@@ -47,12 +47,6 @@ const myResult = fullParser.fork(
   // The string to parse
   'goodbye',
 
-  // An success handler
-  (result, parsingResult) => {
-    console.log(`The final result: ${result}`);
-    return result;
-  },
-
   // An error handler
   (error, parsingResult) => {
     // Here we can throw the error...
@@ -62,7 +56,13 @@ const myResult = fullParser.fork(
     if (error === somethingICanRecoverFrom) {
       return someOtherValue;
     }
-  }
+  },
+  
+  // A success handler
+  (result, parsingResult) => {
+    console.log(`The final result: ${result}`);
+    return result;
+  },
 );
 ```
 

--- a/tutorial/tutorial-part-3.md
+++ b/tutorial/tutorial-part-3.md
@@ -62,7 +62,7 @@ const myResult = fullParser.fork(
   (result, parsingResult) => {
     console.log(`The final result: ${result}`);
     return result;
-  },
+  }
 );
 ```
 


### PR DESCRIPTION
The `fork()` method takes input, errorHandler and successHandler, not the other way around.

## Fix documentation on the use of the `fork()` method

- [x] This PR  only introduces changes to documentation.
  - Please include a summary of changes and an explanation
- [ ] This PR adds new functionality
  - [ ] Is there a related issue?
    - Please note the related issue below, and how this PR relates to the issue if appropriate
  - [ ] Does the code style reasonably match the existing code?
  - [ ] Are the changes tested (using the existing format, as far as is possible?)
  - [ ] Are the changes documented in the readme with a suitable example?
  - [ ] Is the table of contents updated?
- [ ] This PR introduces some other kind of change
  - Please explain the change below