### PR TITLE
Fixed typo

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -978,7 +978,7 @@ export const endOfInput = new Parser(function endOfInput$state(state) {
 
     return updateError(
       state,
-      `ParseError 'endOfInput' (position ${index}): Expected end of input but got '${errorByte}}'`,
+      `ParseError 'endOfInput' (position ${index}): Expected end of input but got '${errorByte}'`,
     );
   }
 


### PR DESCRIPTION
There's a small typo in one of the error messages, an extra closing brace. I removed it