### PR TITLE
Implement packrat parsing

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,39 @@
+type Function_ = (...x: never[]) => unknown;
+
+type Memoize<F extends Function_> = {
+  (...x: Parameters<F>): ReturnType<F>;
+  clearCache: () => void;
+};
+
+const memoizedFunctions: Memoize<Function_>[] = [];
+
+export const memoize = <F extends Function_>(
+  fn: F,
+) => {
+  const cache = new Map<string, unknown>();
+
+  const memoizedFunction = ((...x: never[]) => {
+    const hash = JSON.stringify(x);
+    if (cache.has(hash)) {
+      return cache.get(hash);
+    } else {
+      return fn(...x);
+    }
+  }) as F;
+
+  const memoizedCallableObject = Object.assign(memoizedFunction, {
+    clearCache: () => {
+      cache.clear();
+    }
+  });
+
+  memoizedFunctions.push(memoizedCallableObject);
+
+  return memoizedCallableObject;
+};
+
+export const clearCache = () => {
+  memoizedFunctions.forEach(memoizedFunction => {
+    memoizedFunction.clearCache();
+  });
+}


### PR DESCRIPTION
# Packrat Parsing Implementation

As discussed in #74, this pull request implements packrat parsing using a internally specified set of memoization functions in `./src/cache.ts`.

- [1. Checklist](#1-checklist)
- [2. Discussion](#2-discussion)
  - [2.1. Incremental Parsing](#21-incremental-parsing)
- [3. Suggested release notes](#3-suggested-release-notes)
- [4. Questions to resolve:](#4-questions-to-resolve)

## 1. Checklist

- [ ] This PR  only introduces changes to documentation.
  - Please include a summary of changes and an explanation
- [X] This PR adds new functionality
  - [X] Is there a related issue?
    - Please note the related issue below, and how this PR relates to the issue if appropriate
  - [X] Does the code style reasonably match the existing code?
  - [ ] Are the changes tested (using the existing format, as far as is possible?)
  - [ ] Are the changes documented in the readme with a suitable example?
  - [ ] Is the table of contents updated?
- [ ] This PR introduces some other kind of change
  - Please explain the change below
  
## 2. Discussion

Packrat parsing [[1]](https://pdos.csail.mit.edu/~baford/packrat/thesis/) is a technique for enabling linear-time backtracking in top-down parsers. A common issue with recursive descent parsing is exponential time blowup, whereby the time it takes to parse a string scales exponentially with respect to input length.

Our implementation here using a memoization wrapper around the incremental state update function for each parser. The full, global cache state is cleared on every run.

[[1] Packrat Parsing: a Practical Linear-Time Algorithm with Backtracking (PDF). Bryan Ford, 2002, MIT](https://pdos.csail.mit.edu/~baford/packrat/thesis/)

### 2.1. Race Condition Risk

If two instances of `run` are running in parallel, this could lead to a poisoned cache, and incorrect parse results. Since the parser does not operate on the basis of Promises, it is unclear to me whether this is an important risk.

### 2.2. Incremental Parsing

This implementation resets the global cache on every `run` and `fork` call. This is necessary to avoid errors in parsing - because the cache is parameterized only on `state`, and not `target`, the cache can become poisoned unless it is refreshed on every individual run.

On our fork, I think we will attempt to parameterize the state update cache with `target`, so that the cache may persist across multiple runs, thereby implementing efficient incremental parsing. A configurable LRU cache will be utilized to prevent arbitrary memory usage.

I have avoided implementing this more advanced form in this pull request, as it is a lot more experimental, opinionated, and risky. As yet, I am not convinced it's even possible to do easily - if `target` always corresponds to do full input, then parameterizing the cache on `target` won't implement incremental parsing.

## 3. Suggested release notes

Versioning is left up to maintainer discretion, but for convenience here is my suggested changelog.

```md
## 4.1.0

- Implement Packrat Parsing to improve cyclomatic performance
  - All incremental state update functions are cached
  - The entire cache is cleared before `run` or `fork` begins parsing
 ```

## 4. Questions to resolve:

* Do we want tests for `cache.ts`? I did not want to unnecessarily bloat the pull request, but if we want them I can write some.
* Do we want to wait for incremental linear parsing after all?
* Should changing the cyclomatic complexity of a function count as a breaking change?
* Is any additional documentation necessary about this internal design?
