### PR TITLE
Improve performace by caching DataView utf8 strings instead of decoding each time

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/benchmark.js
+++ b/benchmark.js
@@ -13,7 +13,8 @@ const {
   optionalWhitespace,
   between,
   anyOfString,
-  recursiveParser
+  recursiveParser,
+  encoder,
 } = require('.');
 
 const parseJsonValue = recursiveParser(() => choice ([
@@ -113,8 +114,17 @@ for (const [ name, json ] of Object.entries({ smallJson, mediumJson, largeJson }
       JSON.parse(json);
     }),
 
-    b.add('parseJsonValue', () => {
+    b.add('parseJsonValue on string', () => {
       parseJsonValue.run(json);
+    }),
+
+    b.add('parseJsonValue on DataView', () => {
+      const bytes = encoder.encode(json);
+      const dataView = new DataView(bytes.buffer);
+
+      return () => {
+        parseJsonValue.run(dataView);
+      };
     }),
 
     b.cycle(),

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,123 @@
+const b = require('benny');
+
+const {
+  char,
+  sequenceOf,
+  str,
+  choice,
+  possibly,
+  sepBy,
+  many,
+  anythingExcept,
+  digits,
+  optionalWhitespace,
+  between,
+  anyOfString,
+  recursiveParser
+} = require('.');
+
+const parseJsonValue = recursiveParser(() => choice ([
+  parseNumber,
+  parseBool,
+  parseNull,
+  parseString,
+  parseArray,
+  parseObject,
+]));
+
+const escapedQuote = sequenceOf ([ str ('\\'), anyOfString (`"'`) ]).map(x => x.join(''));
+
+const whitespaceSurrounded = parser => between (optionalWhitespace) (optionalWhitespace) (parser);
+const commaSeparated = sepBy (whitespaceSurrounded (char (',')));
+const orEmptyString = parser => possibly(parser).map(x => x ? x : '');
+const join = seperator => array => array.join(seperator);
+
+const parseBool = choice([ str ('true'), str ('false') ]).map(s => s === 'true')
+
+const plusOrMinus = anyOfString ('+-');
+
+const parseFloat = sequenceOf([
+  orEmptyString(plusOrMinus),
+  digits,
+  char ('.'),
+  digits
+]).map(join(''));
+
+const parseInt = sequenceOf([ orEmptyString(plusOrMinus), digits ]).map(join(''))
+
+const parseScientificForm = sequenceOf([
+  choice ([ parseFloat, parseInt ]),
+  anyOfString ('eE'),
+  choice ([ parseFloat, parseInt ]),
+]).map(join(''));
+
+const parseNumber = choice([
+  parseScientificForm,
+  parseFloat,
+  parseInt,
+]).map(s => Number(s));
+
+const parseNull = str ('null').map(() => null);
+
+const keyValueSeparator = whitespaceSurrounded (char (':'));
+
+const parseArray = between (whitespaceSurrounded (char ('[')))
+                            (whitespaceSurrounded (char (']')))
+                            (commaSeparated (parseJsonValue));
+
+const parseString = sequenceOf ([
+  char ('"'),
+  many (choice ([ escapedQuote, anythingExcept (char ('"')) ])).map(join('')),
+  char ('"')
+]).map(x => x.join(''));
+
+const parseKeyValue = whitespaceSurrounded (sequenceOf ([
+  parseString,
+  keyValueSeparator,
+  parseJsonValue,
+])).map(([key, _, value]) => [ key, value ]);
+
+const parseObject = between (whitespaceSurrounded (char ('{')))
+                            (whitespaceSurrounded (char ('}')))
+                            (commaSeparated (parseKeyValue));
+
+const smallJson = JSON.stringify({
+  a: 1,
+  b: [1, 2, 3],
+  c: 'hello'
+});
+
+const mediumJson = JSON.stringify({
+  a: 1,
+  b: [1, 2, 3],
+  c: 'hello',
+  d: JSON.parse(smallJson),
+  dString: smallJson,
+});
+
+const largeJson = JSON.stringify(Array.from({ length: 16 }).reduce((largeJson, _, i) => {
+  return {
+    ...largeJson,
+    [`smallJson${i}`]: JSON.parse(smallJson),
+    [`smallJsonString${i}`]: smallJson,
+    [`mediumJson${i}`]: JSON.parse(mediumJson),
+    [`mediumJsonString${i}`]: mediumJson,
+  };
+}, JSON.parse(smallJson)));
+
+for (const [ name, json ] of Object.entries({ smallJson, mediumJson, largeJson })) {
+  b.suite(
+    'JSON.parse vs parseJsonValue on ' + name,
+
+    b.add('JSON.parse', () => {
+      JSON.parse(json);
+    }),
+
+    b.add('parseJsonValue', () => {
+      parseJsonValue.run(json);
+    }),
+
+    b.cycle(),
+    b.complete(),
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@rollup/plugin-typescript": "^8.2.1",
         "@types/node": "^15.12.5",
+        "benny": "^3.7.1",
         "eslint": "^6.8.0",
         "eslint-config-prettier": "^6.10.0",
         "eslint-plugin-prettier": "^3.1.2",
@@ -22,6 +23,48 @@
         "rollup-plugin-dts": "^3.0.2",
         "standard": "^14.3.1",
         "typescript": "^4.3.4"
+      }
+    },
+    "node_modules/@arrows/array": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@arrows/array/-/array-1.4.1.tgz",
+      "integrity": "sha512-MGYS8xi3c4tTy1ivhrVntFvufoNzje0PchjEz6G/SsWRgUKxL4tKwS6iPdO8vsaJYldagAeWMd5KRD0aX3Q39g==",
+      "dev": true,
+      "dependencies": {
+        "@arrows/composition": "^1.2.2"
+      }
+    },
+    "node_modules/@arrows/composition": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@arrows/composition/-/composition-1.2.2.tgz",
+      "integrity": "sha512-9fh1yHwrx32lundiB3SlZ/VwuStPB4QakPsSLrGJFH6rCXvdrd060ivAZ7/2vlqPnEjBkPRRXOcG1YOu19p2GQ==",
+      "dev": true
+    },
+    "node_modules/@arrows/dispatch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@arrows/dispatch/-/dispatch-1.0.3.tgz",
+      "integrity": "sha512-v/HwvrFonitYZM2PmBlAlCqVqxrkIIoiEuy5bQgn0BdfvlL0ooSBzcPzTMrtzY8eYktPyYcHg8fLbSgyybXEqw==",
+      "dev": true,
+      "dependencies": {
+        "@arrows/composition": "^1.2.2"
+      }
+    },
+    "node_modules/@arrows/error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@arrows/error/-/error-1.0.2.tgz",
+      "integrity": "sha512-yvkiv1ay4Z3+Z6oQsUkedsQm5aFdyPpkBUQs8vejazU/RmANABx6bMMcBPPHI4aW43VPQmXFfBzr/4FExwWTEA==",
+      "dev": true
+    },
+    "node_modules/@arrows/multimethod": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@arrows/multimethod/-/multimethod-1.4.1.tgz",
+      "integrity": "sha512-AZnAay0dgPnCJxn3We5uKiB88VL+1ZIF2SjZohLj6vqY2UyvB/sKdDnFP+LZNVsTC5lcnGPmLlRRkAh4sXkXsQ==",
+      "dev": true,
+      "dependencies": {
+        "@arrows/array": "^1.4.1",
+        "@arrows/composition": "^1.2.2",
+        "@arrows/error": "^1.0.2",
+        "fast-deep-equal": "^3.1.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1177,6 +1220,45 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
+    "node_modules/benny": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/benny/-/benny-3.7.1.tgz",
+      "integrity": "sha512-USzYxODdVfOS7JuQq/L0naxB788dWCiUgUTxvN+WLPt/JfcDURNNj8kN/N+uK6PDvuR67/9/55cVKGPleFQINA==",
+      "dev": true,
+      "dependencies": {
+        "@arrows/composition": "^1.0.0",
+        "@arrows/dispatch": "^1.0.2",
+        "@arrows/multimethod": "^1.1.6",
+        "benchmark": "^2.1.4",
+        "common-tags": "^1.8.0",
+        "fs-extra": "^10.0.0",
+        "json2csv": "^5.0.6",
+        "kleur": "^4.1.4",
+        "log-update": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/benny/node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -1515,6 +1597,24 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/component-emitter": {
@@ -2971,6 +3071,20 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/fs.realpath": {
@@ -4585,6 +4699,25 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "node_modules/json2csv": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-5.0.7.tgz",
+      "integrity": "sha512-YRZbUnyaJZLZUJSRi2G/MqahCyRv9n/ds+4oIetjDF3jWQA7AG7iSeKTiZiCNqtMZM7HDyt0e/W6lEnoGEmMGA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "dependencies": {
+        "commander": "^6.1.0",
+        "jsonparse": "^1.3.1",
+        "lodash.get": "^4.4.2"
+      },
+      "bin": {
+        "json2csv": "bin/json2csv.js"
+      },
+      "engines": {
+        "node": ">= 10",
+        "npm": ">= 6.13.0"
+      }
+    },
     "node_modules/json5": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -4599,6 +4732,27 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ]
     },
     "node_modules/jsprim": {
       "version": "1.4.1",
@@ -4711,11 +4865,179 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
+    },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
+    },
+    "node_modules/log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/log-update/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -5514,6 +5836,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "dev": true
     },
     "node_modules/pn": {
       "version": "1.1.0",
@@ -6972,6 +7300,15 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
@@ -7324,6 +7661,48 @@
     }
   },
   "dependencies": {
+    "@arrows/array": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@arrows/array/-/array-1.4.1.tgz",
+      "integrity": "sha512-MGYS8xi3c4tTy1ivhrVntFvufoNzje0PchjEz6G/SsWRgUKxL4tKwS6iPdO8vsaJYldagAeWMd5KRD0aX3Q39g==",
+      "dev": true,
+      "requires": {
+        "@arrows/composition": "^1.2.2"
+      }
+    },
+    "@arrows/composition": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@arrows/composition/-/composition-1.2.2.tgz",
+      "integrity": "sha512-9fh1yHwrx32lundiB3SlZ/VwuStPB4QakPsSLrGJFH6rCXvdrd060ivAZ7/2vlqPnEjBkPRRXOcG1YOu19p2GQ==",
+      "dev": true
+    },
+    "@arrows/dispatch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@arrows/dispatch/-/dispatch-1.0.3.tgz",
+      "integrity": "sha512-v/HwvrFonitYZM2PmBlAlCqVqxrkIIoiEuy5bQgn0BdfvlL0ooSBzcPzTMrtzY8eYktPyYcHg8fLbSgyybXEqw==",
+      "dev": true,
+      "requires": {
+        "@arrows/composition": "^1.2.2"
+      }
+    },
+    "@arrows/error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@arrows/error/-/error-1.0.2.tgz",
+      "integrity": "sha512-yvkiv1ay4Z3+Z6oQsUkedsQm5aFdyPpkBUQs8vejazU/RmANABx6bMMcBPPHI4aW43VPQmXFfBzr/4FExwWTEA==",
+      "dev": true
+    },
+    "@arrows/multimethod": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@arrows/multimethod/-/multimethod-1.4.1.tgz",
+      "integrity": "sha512-AZnAay0dgPnCJxn3We5uKiB88VL+1ZIF2SjZohLj6vqY2UyvB/sKdDnFP+LZNVsTC5lcnGPmLlRRkAh4sXkXsQ==",
+      "dev": true,
+      "requires": {
+        "@arrows/array": "^1.4.1",
+        "@arrows/composition": "^1.2.2",
+        "@arrows/error": "^1.0.2",
+        "fast-deep-equal": "^3.1.3"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
@@ -8250,6 +8629,41 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
+    "benny": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/benny/-/benny-3.7.1.tgz",
+      "integrity": "sha512-USzYxODdVfOS7JuQq/L0naxB788dWCiUgUTxvN+WLPt/JfcDURNNj8kN/N+uK6PDvuR67/9/55cVKGPleFQINA==",
+      "dev": true,
+      "requires": {
+        "@arrows/composition": "^1.0.0",
+        "@arrows/dispatch": "^1.0.2",
+        "@arrows/multimethod": "^1.1.6",
+        "benchmark": "^2.1.4",
+        "common-tags": "^1.8.0",
+        "fs-extra": "^10.0.0",
+        "json2csv": "^5.0.6",
+        "kleur": "^4.1.4",
+        "log-update": "^4.0.0"
+      },
+      "dependencies": {
+        "kleur": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+          "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+          "dev": true
+        }
+      }
+    },
     "bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -8550,6 +8964,18 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true
+    },
+    "common-tags": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+      "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+      "dev": true
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -9734,6 +10160,17 @@
       "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
+      }
+    },
+    "fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       }
     },
     "fs.realpath": {
@@ -11040,6 +11477,17 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "json2csv": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-5.0.7.tgz",
+      "integrity": "sha512-YRZbUnyaJZLZUJSRi2G/MqahCyRv9n/ds+4oIetjDF3jWQA7AG7iSeKTiZiCNqtMZM7HDyt0e/W6lEnoGEmMGA==",
+      "dev": true,
+      "requires": {
+        "commander": "^6.1.0",
+        "jsonparse": "^1.3.1",
+        "lodash.get": "^4.4.2"
+      }
+    },
     "json5": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -11048,6 +11496,22 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -11136,11 +11600,130 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
+    },
+    "log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+          "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.21.3"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "astral-regex": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -11782,6 +12365,12 @@
       "requires": {
         "find-up": "^3.0.0"
       }
+    },
+    "platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "dev": true
     },
     "pn": {
       "version": "1.1.0",
@@ -12960,6 +13549,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
+    "universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true
     },
     "unset-value": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@rollup/plugin-typescript": "^8.2.1",
     "@types/node": "^15.12.5",
+    "benny": "^3.7.1",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
     "eslint-plugin-prettier": "^3.1.2",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,4 @@
-import { encoder } from './unicode';
+import { encoder, setDataViewString } from './unicode';
 import { InputType, InputTypes, isTypedArray } from './inputTypes';
 
 // createParserState :: x -> s -> ParserState e a s
@@ -10,6 +10,7 @@ const createParserState = <D>(target: InputType, data: D | null = null): ParserS
     const bytes = encoder.encode(target);
     dataView = new DataView(bytes.buffer);
     inputType = InputTypes.STRING;
+    setDataViewString(dataView, target);
   } else if (target instanceof ArrayBuffer) {
     dataView = new DataView(target);
     inputType = InputTypes.ARRAY_BUFFER;

--- a/src/unicode.ts
+++ b/src/unicode.ts
@@ -16,7 +16,18 @@ if (typeof TextEncoder !== 'undefined') {
 export const encoder = new text.Encoder();
 export const decoder = new text.Decoder();
 
+const dataViewStringCache = new WeakMap<DataView, string>();
+
+export const setDataViewString = (dataView: DataView, string: string) => {
+  dataViewStringCache.set(dataView, string);
+}
+
 export const getString = (index: number, length: number, dataView: DataView) => {
+  if (dataViewStringCache.has(dataView)) {
+    const cachedString = dataViewStringCache.get(dataView)!;
+    const decodedStringFromCache = cachedString.slice(index, index + length);
+    return decodedStringFromCache;
+  }
   const bytes = Uint8Array.from({ length }, (_, i) =>
     dataView.getUint8(index + i)
   );
@@ -33,12 +44,7 @@ export const getNextCharWidth = (index: number, dataView: DataView) => {
   return 1;
 };
 
-export const getUtf8Char = (index: number, length: number, dataView: DataView) => {
-  const bytes = Uint8Array.from({ length }, (_, i) =>
-    dataView.getUint8(index + i),
-  );
-  return decoder.decode(bytes);
-};
+export const getUtf8Char = getString;
 
 export const getCharacterLength = (str: string) => {
   let cp;


### PR DESCRIPTION
It's 2 times faster on small inputs and infinitely faster on large ones. Below output has "parseJsonValue on DataView" benchmark which serves as an uncached reference, although it's performance can be improved too by encoding the whole input once ahead of time, I'm not sure if that's a good idea.

<details>
<summary>`node ./benchmark.js`</summary>

```
Running "JSON.parse vs parseJsonValue on smallJson" suite...
Progress: 100%

  JSON.parse:
    1 489 173 ops/s, ±3.29%   | fastest

  parseJsonValue on string:
    7 017 ops/s, ±1.61%       | 99.53% slower

  parseJsonValue on DataView:
    3 771 ops/s, ±1.38%       | slowest, 99.75% slower

Finished 3 cases!
  Fastest: JSON.parse
  Slowest: parseJsonValue on DataView
Running "JSON.parse vs parseJsonValue on mediumJson" suite...
Progress: 100%

  JSON.parse:
    679 218 ops/s, ±1.58%   | fastest

  parseJsonValue on string:
    2 720 ops/s, ±1.56%     | 99.6% slower

  parseJsonValue on DataView:
    785 ops/s, ±1.61%       | slowest, 99.88% slower

Finished 3 cases!
  Fastest: JSON.parse
  Slowest: parseJsonValue on DataView
Running "JSON.parse vs parseJsonValue on largeJson" suite...
Progress: 100%

  JSON.parse:
    23 849 ops/s, ±1.82%   | fastest

  parseJsonValue on string:
    75 ops/s, ±1.34%       | 99.69% slower

  parseJsonValue on DataView:
    1 ops/s, ±2.28%        | slowest, 100% slower

Finished 3 cases!
  Fastest: JSON.parse
  Slowest: parseJsonValue on DataView
```

</details>